### PR TITLE
small bug on non-default separator

### DIFF
--- a/src/ofxCsv.cpp
+++ b/src/ofxCsv.cpp
@@ -102,7 +102,8 @@ namespace wng {
 					rows.push_back(temp);
 				
 					// Split row into cols.
-					vector<string> cols = ofSplitString(rows[lineCount], ",");
+				// formerly was: vector<string> cols = ofSplitString(rows[lineCount], ",");
+					vector<string> cols = ofSplitString(rows[lineCount], separator);
 				
 					// Write the string to data.
 					data.push_back(cols);


### PR DESCRIPTION
line 105 of ofxCsv.cpp: there was a fixed "," instead of a separator var, making it fails when you set a separator different from the default one.
Let me say thank you for this really nice add-on, I use it a lot! ;)
