### PR TITLE
Fixed issues when clearing and reloading data

### DIFF
--- a/src/ofxCsv.cpp
+++ b/src/ofxCsv.cpp
@@ -205,9 +205,13 @@ namespace wng {
 			// Write data to file.
 			for(int i=0; i<numRows; i++){
 				for(int j=0; j<data[i].size(); j++){
-					myfile << data[i][j] << separator;
+					
+					myfile << data[i][j];
+					
 					if(j==(data[i].size()-1)){
 						myfile << "\n";
+					} else {
+						myfile << separator;
 					}
 				}
 			}


### PR DESCRIPTION
When using ofxCsv to collect and save data multiple times in the same app I needed to also reset the numRows.

I get empty columns at the end of the .csv because of the extra comma being added at the end, so I check the number of columns before appending the seperator to each value within a row.
