### PR TITLE
initializing field numRows, in order to avoid vector subscript out of range error

### DIFF
--- a/src/ofxCsv.cpp
+++ b/src/ofxCsv.cpp
@@ -50,6 +50,7 @@ namespace wng {
 		
 		// set the default seperator value
 		fileSeparator = ",";
+		numRows = 0;
 	}
 
 


### PR DESCRIPTION
I'm using windows and this is essential for this addon not to crash. Nothing big, the rest is fine. cheers for addon!
