### PR TITLE
Fix for cpp-11

### DIFF
--- a/src/ofxCsv.cpp
+++ b/src/ofxCsv.cpp
@@ -90,10 +90,11 @@ namespace wng {
 		if(fileIn.is_open()) {
 			int lineCount = 0;
 			vector<string> rows;
-		
-			while(fileIn != NULL) {
-				string temp;		
-				getline(fileIn, temp);
+
+            string temp;
+			while(getline(fileIn, temp)) {
+
+
 			
 				// Skip empty lines.
 				if(temp.length() == 0) {


### PR DESCRIPTION
Hey,

Very useful addon.

OpenFrameworks is moving to cpp-11/64-bit in for v0.9. This fix is needed (on my machine anyway).

Thanks,
C